### PR TITLE
import torch.nn as nn in reinforce_agent.py

### DIFF
--- a/lagom/agents/reinforce_agent.py
+++ b/lagom/agents/reinforce_agent.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn as nn
 from torch.distributions import Categorical
 
 from .base_agent import BaseAgent


### PR DESCRIPTION
__nn__ is used on line 88 but it is not imported or defined.

flake8 testing of https://github.com/zuoxingdong/lagom on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lagom/agents/reinforce_agent.py:87:13: F821 undefined name 'nn'
            nn.utils.clip_grad_norm_(parameters=self.policy.network.parameters(),
            ^
1     F821 undefined name 'nn'
1
```