### PR TITLE
Undefined name: all_data in curve_plot.py

### DIFF
--- a/lagom/core/plotter/curve_plot.py
+++ b/lagom/core/plotter/curve_plot.py
@@ -129,6 +129,6 @@ class CurvePlot(BasePlot):
         elif x.ndim == 2:
             x = x
         else:
-            raise TypeError(f'The input data must be either one- or two-dimensional. But got {all_data.ndim}.')
+            raise TypeError(f'The input data must be either one- or two-dimensional. But got {x.ndim}.')
             
         return x


### PR DESCRIPTION
__all_data__ is an undefined name in this context but the function has been dealing with __x.ndim__.

flake8 testing of https://github.com/zuoxingdong/lagom on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lagom/core/plotter/curve_plot.py:132:95: F821 undefined name 'all_data'
            raise TypeError(f'The input data must be either one- or two-dimensional. But got {all_data.ndim}.')
                                                                                              ^
1     F821 undefined name 'all_data'
1
```